### PR TITLE
Fixed typographical error, changed abondoned to abandoned in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ at the same time including support for multiple user accounts.
 Some [Screenshots](docs/screenshots.md).
 
 This project was big and a mostly complete (multiple protocols/GUIs/Skins/Translations).
-But it was abondoned because the the D environment changed a lot and the
+But it was abandoned because the the D environment changed a lot and the
 authors interests changed. Still, this project has a lot of interesting code.
 
 * Supports MLDonkey/aMule/rTorrent and giFT (uses the remote GUI protocol!)


### PR DESCRIPTION
mwarning, I've corrected a typographical error in the documentation of the [p2p-gui](https://github.com/mwarning/p2p-gui) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
